### PR TITLE
オオサカドンの位置調整

### DIFF
--- a/app/assets/stylesheets/components.scss
+++ b/app/assets/stylesheets/components.scss
@@ -1266,7 +1266,7 @@ a.status__content__spoiler-link {
 .getting-started {
   box-sizing: border-box;
   padding-bottom: 235px;
-  background: image-url('mastodon-getting-started.png') no-repeat 0 100% local;
+  background: image-url('mastodon-getting-started.png') no-repeat 100% 100% local;
   flex: 1 0 auto;
 
   p {


### PR DESCRIPTION
カラム可変化によって幅広のディスプレイでは左寄せだと違和感あるので右寄せにしました