### PR TITLE
左下の余白にロゴを配置

### DIFF
--- a/app/javascript/mastodon/features/compose/index.js
+++ b/app/javascript/mastodon/features/compose/index.js
@@ -69,12 +69,14 @@ export default class Compose extends React.PureComponent {
           <div className='drawer__inner'>
             <NavigationContainer />
             <ComposeFormContainer />
+            <div className='drawer__inner__background'></div>
           </div>
 
           <Motion defaultStyle={{ x: -100 }} style={{ x: spring(showSearch ? 0 : -100, { stiffness: 210, damping: 20 }) }}>
             {({ x }) =>
               <div className='drawer__inner darker' style={{ transform: `translateX(${x}%)`, visibility: x === -100 ? 'hidden' : 'visible' }}>
                 <SearchResultsContainer />
+                <div className='drawer__inner__background'></div>
               </div>
             }
           </Motion>

--- a/app/javascript/styles/components.scss
+++ b/app/javascript/styles/components.scss
@@ -1397,6 +1397,12 @@
   }
 }
 
+.drawer__inner__background {
+  flex: 1 0 auto;
+  background: url('../images/fluffy-elephant-friend.png') no-repeat 50% 100%/contain local;
+  opacity: 0.8;
+}
+
 .pseudo-drawer {
   background: lighten($ui-base-color, 13%);
   font-size: 13px;


### PR DESCRIPTION
トゥート画面の下側が淋しいんで、湊川先生の象さんを置いてみるのはどやろかという提案です。
余った余白に合わせてサイズを変更しとります。

* * *

![](https://storage.googleapis.com/mstdn-osaka/media_attachments/files/000/211/679/original/629dc7592f711b15.png "トゥート画面")

![](https://storage.googleapis.com/mstdn-osaka/media_attachments/files/000/211/677/original/38e8675ebe3a5b2e.png "検索画面")